### PR TITLE
restore inner links functionality when using gzip

### DIFF
--- a/check_webpage.rb
+++ b/check_webpage.rb
@@ -522,7 +522,7 @@ if DEBUG >= 1 then puts "[#{res.code}] #{res.message} s(#{totalSizeReport}) t(#{
 
 ## inner links part
 ###############################################################
-getInnerLinks(mainUrl, res.body, httpHeaders, reports, proxy) unless GET_INNER_LINKS == 0
+getInnerLinks(mainUrl, res_body, httpHeaders, reports, proxy) unless GET_INNER_LINKS == 0
 
 ## Get Statistics
 ###############################################################


### PR DESCRIPTION
This small change restores the inner links functionality when using gzip encoding. This was broken by change #21 