### PR TITLE
Added ".strip" to "check_webpage.rb"

### DIFF
--- a/check_webpage.rb
+++ b/check_webpage.rb
@@ -405,11 +405,11 @@ def getInnerLinks (mainUrl, data, httpHeaders, reports, proxy)
 
   ## Parsing main page data
   doc = Hpricot(data)
-  parsingResult =                 doc.search("//img[@src]").map { |x| x['src'] }
-  parsingResult = parsingResult + doc.search("//script[@src]").map { |x| x['src'] }
-  parsingResult = parsingResult + doc.search("//input[@src]").map { |x| x['src'] }
-  parsingResult = parsingResult + doc.search("//link[@href]").map { |x| x['href'] }
-  parsingResult = parsingResult + doc.search("//embed[@src]").map { |x| x['src'] }
+  parsingResult =                 doc.search("//img[@src]").map { |x| x['src'].strip }
+  parsingResult = parsingResult + doc.search("//script[@src]").map { |x| x['src'].strip }
+  parsingResult = parsingResult + doc.search("//input[@src]").map { |x| x['src'].strip }
+  parsingResult = parsingResult + doc.search("//link[@href]").map { |x| x['href'].strip }
+  parsingResult = parsingResult + doc.search("//embed[@src]").map { |x| x['src'].strip }
 
   #link_path is path without filename
   link_path = /.*\//.match(mainUrl.path)[0]


### PR DESCRIPTION
Added ".strip" to "check_webpage.rb" to prevent errors when leading or trailing whitespace exists in URL