### PR TITLE
Fixed total size report for inner links

### DIFF
--- a/check_webpage.rb
+++ b/check_webpage.rb
@@ -584,6 +584,10 @@ if keyword != nil
   end
 end
 
+## inner links part
+###############################################################
+getInnerLinks(mainUrl, res_body, httpHeaders, reports, proxy) unless GET_INNER_LINKS == 0
+
 ## set total size report
 ###############################################################
 if reports['totalSize'] < 1000
@@ -600,10 +604,6 @@ if !GRAPHITE_HOST.nil?
   graphite.push GRAPHITE_BUCKET+'.'+'mainpage_time', (Time.now-startedTime)*1000
   graphite.push GRAPHITE_BUCKET+'.'+'mainpage_size', reports['totalSize']
 end
-
-## inner links part
-###############################################################
-getInnerLinks(mainUrl, res_body, httpHeaders, reports, proxy) unless GET_INNER_LINKS == 0
 
 ## Get Statistics
 ###############################################################


### PR DESCRIPTION
I just found out, that the total size report is generated before the inner links are fetched, therefor these won't be calculated towards the total size.

I just moved the call to getInnerLinks befor the report generation.

Regards,
Markus
